### PR TITLE
Enable connection

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,19 @@
 use std::{net::{Ipv4Addr, SocketAddr}, time::Duration};
 use crate::{protocol::*, shared::*};
 use bevy::{log::LogPlugin, prelude::*};
+use bevy::log::Level;
 use lightyear::{prelude::{client::{self, *}, LinkConditionerConfig}, shared::config::Mode, transport::io::{IoConfig, TransportConfig}};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 
 pub fn build_client_app() -> App{
     let mut app = App::new();
-    app.add_plugins((DefaultPlugins.build().disable::<LogPlugin>(), WorldInspectorPlugin::new()));
+    app.add_plugins((DefaultPlugins.build().set(LogPlugin {
+        level: Level::INFO,
+        filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
+        update_subscriber: None,
+    }), WorldInspectorPlugin::new()));
     let client_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0);
-    let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 5001);
+    let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 5001);
     let auth = Authentication::Manual {
         server_addr,
         client_id: 0,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,41 +1,57 @@
-use std::{net::{Ipv4Addr, SocketAddr}, time::Duration};
+use std::{
+    net::{Ipv4Addr, SocketAddr},
+    time::Duration,
+};
 
+use bevy::log::Level;
 use bevy::{log::LogPlugin, prelude::*};
-use lightyear::{prelude::{server, LinkConditionerConfig}, shared::config::Mode, transport::io::{IoConfig, TransportConfig}};
-use lightyear::prelude::server::*;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use lightyear::prelude::server::*;
+use lightyear::{
+    prelude::{server, LinkConditionerConfig},
+    shared::config::Mode,
+    transport::io::{IoConfig, TransportConfig},
+};
 
 use crate::{protocol::*, shared::*};
 
 pub fn build_server_app() -> App {
-let mut app = App::new();
-app.add_plugins((DefaultPlugins.build().disable::<LogPlugin>(), WorldInspectorPlugin::new()));
+    let mut app = App::new();
+    app.add_plugins((
+        DefaultPlugins.build().set(LogPlugin {
+            level: Level::INFO,
+            filter: "wgpu=error,bevy_render=info,bevy_ecs=warn".to_string(),
+            update_subscriber: None,
+        }),
+        WorldInspectorPlugin::new(),
+    ));
 
-let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 5001);
-let netcode_config = NetcodeConfig::default()
-    .with_protocol_id(PROTOCOL_ID)
-    .with_key(KEY);
-let link_conditioner = LinkConditionerConfig {
-    incoming_latency: Duration::from_millis(100),
-    incoming_jitter: Duration::from_millis(0),
-    incoming_loss: 0.00,
-};
-let io_config = IoConfig::from_transport(TransportConfig::UdpSocket(server_addr)).with_conditioner(link_conditioner);
+    let server_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 5001);
+    let netcode_config = NetcodeConfig::default()
+        .with_protocol_id(PROTOCOL_ID)
+        .with_key(KEY);
+    let link_conditioner = LinkConditionerConfig {
+        incoming_latency: Duration::from_millis(100),
+        incoming_jitter: Duration::from_millis(0),
+        incoming_loss: 0.00,
+    };
+    let io_config = IoConfig::from_transport(TransportConfig::UdpSocket(server_addr))
+        .with_conditioner(link_conditioner);
 
-let net_config = server::NetConfig::Netcode { 
-    config: netcode_config, 
-    io: io_config 
-};
+    let net_config = server::NetConfig::Netcode {
+        config: netcode_config,
+        io: io_config,
+    };
 
-let server_config = ServerConfig {
-    shared: shared_config(Mode::Separate).clone(),
-    net: vec![net_config],
-    ..Default::default()
-};
-let plugin_config = PluginConfig::new(server_config, protocol());
-app.add_plugins(server::ServerPlugin::new(plugin_config));
-app.add_systems(Startup, init);
-app
+    let server_config = ServerConfig {
+        shared: shared_config(Mode::Separate).clone(),
+        net: vec![net_config],
+        ..Default::default()
+    };
+    let plugin_config = PluginConfig::new(server_config, protocol());
+    app.add_plugins(server::ServerPlugin::new(plugin_config));
+    app.add_systems(Startup, init);
+    app
 }
 
 fn init(mut connections: ResMut<ServerConnections>) {


### PR DESCRIPTION
3 changes:
- ran rustfmt to reformat the code
- enable the LogPlugin to see the logs
- changed the server_addr on the `client.rs` from `UNSPECIFIED` to `LOCALHOST`.

UNSPECIFIED = 0.0.0.0 = the server listens on any network card available on the machine (usually there's only 1, but on some servers you could have multiple)
LOCALHOST = 127.0.0.1
When a client connects to a server, they need to specify the exact address to connect to, even if the server listens on any address (via 0.0.0.1)

See https://stackoverflow.com/questions/20778771/what-is-the-difference-between-0-0-0-0-127-0-0-1-and-localhost#comment127408786_20778887